### PR TITLE
협업을 위한 git hooks 설정

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,13 @@
+commit_msg_file=$1
+commit_msg=$(head -n1 "$commit_msg_file")
+
+regex="^(feat|fix|bugfix|comment|docs|style|refactor|test|chore|perf)(\(.+\))?: .+"
+
+if ! echo "$commit_msg" | grep -qE "$regex"; then
+  echo "Aborting commit."
+  echo "Your commit message does not follow the conventional commit format."
+  echo "Example: 'feat(api): add new endpoint'"
+  echo "Allowed types: feat, fix, bugfix, comment, docs, style, refactor, test, chore, perf"
+  exit 1
+fi
+

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged


### PR DESCRIPTION
### 개요
- 코드 품질을 향상하고, 커밋 히스토리의 일관성을 유지하기 위해 Husky를 사용한 Git Hooks를 설정합니다.
- 이를 통해 커밋 시점에 코드 스타일을 자동으로 검사하고, 표준화된 커밋 메시지 양식을 강제합니다.

### 주요 변경 사항
1. `pre-commit` 훅 설정
    - 커밋 실행 시 lint-staged가 자동으로 실행됩니다.
    - 스테이징된 파일에 대해 ESLint와 Prettier를 실행하여 코드 스타일을 자동으로 교정합니다.
    - 이를 통해 컨벤션에 맞지 않는 코드가 커밋되는 것을 사전에 방지합니다.

2. `commit-msg` 훅 설정
    - 커밋 메시지가 지정된 양식을 따르는지 검사합니다.
    - 허용 타입: feat, fix, bugfix, comment, docs, style, refactor, test, chore, perf
    - 양식에 맞지 않을 경우, 올바른 예시를 안내하며 커밋이 중단됩니다.

### 참고 사항
- #5 
- #6 
- **Ticket**: [FRT-20](https://qgenie.atlassian.net/browse/FRT-20)

[FRT-20]: https://qgenie.atlassian.net/browse/FRT-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ