### PR TITLE
[FRT-27] 전역 에러 처리

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -2,3 +2,4 @@ singleQuote: true
 semi: false
 printWidth: 100
 trailingComma: none
+tabWidth: 2

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,6 @@
 {
-  "recommendations": ["dbaeumer.vscode-eslint"]
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "wayou.vscode-todo-highlight"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,43 @@
   },
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "todohighlight.keywords": [
+    {
+      "text": "HACK",
+      "color": "#ffffff",
+      "backgroundColor": "#8BA9F8",
+      "overviewRulerColor": "#8BA9F8"
+    },
+    {
+      "text": "NOTE",
+      "color": "#ffffff",
+      "backgroundColor": "#FF7F00",
+      "overviewRulerColor": "#FF7F00"
+    },
+    {
+      "text": "BUG",
+      "color": "#ffffff",
+      "backgroundColor": "#F44336",
+      "overviewRulerColor": "#F44336"
+    },
+    {
+      "text": "INFO",
+      "color": "#ffffff",
+      "backgroundColor": "#2196F3",
+      "overviewRulerColor": "#2196F3"
+    },
+    {
+      "text": "OPTIMIZE",
+      "color": "#ffffff",
+      "backgroundColor": "#9C27B0",
+      "overviewRulerColor": "#9C27B0"
+    },
+    {
+      "text": "REVIEW",
+      "color": "#FFFFFF",
+      "backgroundColor": "#8AC038",
+      "overviewRulerColor": "#8AC038"
+    }
+  ]
 }

--- a/components.json
+++ b/components.json
@@ -10,7 +10,7 @@
     "cssVariables": true
   },
   "aliases": {
-    "components": "@/components",
-    "utils": "@/lib/utils"
+    "components": "src/renderer/src/components",
+    "utils": "src/renderer/src/lib/utils"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,10 @@
         "@electron-toolkit/utils": "^4.0.0",
         "clsx": "^2.1.1",
         "electron-updater": "^6.3.9",
+        "lucide-react": "^0.525.0",
+        "next-themes": "^0.4.6",
+        "react-error-boundary": "^6.0.0",
+        "sonner": "^2.0.6",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -321,6 +325,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -7407,7 +7420,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -8072,7 +8084,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -8098,6 +8109,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {
@@ -8508,6 +8528,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/node-abi": {
@@ -9319,7 +9349,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -9332,7 +9361,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -9340,6 +9368,18 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.0.0.tgz",
+      "integrity": "sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-is": {
@@ -9752,7 +9792,6 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -10045,6 +10084,16 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.6.tgz",
+      "integrity": "sha512-yHFhk8T/DK3YxjFQXIrcHT1rGEeTLliVzWbO0xN8GberVun2RiBnxAjXAYpZrqwEVHBG9asI/Li8TAAhN9m59Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
     "@electron-toolkit/utils": "^4.0.0",
     "clsx": "^2.1.1",
     "electron-updater": "^6.3.9",
+    "lucide-react": "^0.525.0",
+    "next-themes": "^0.4.6",
+    "react-error-boundary": "^6.0.0",
+    "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -56,6 +56,9 @@ app.on('window-all-closed', () => {
   }
 })
 
+/**
+ * NOTE: sandbox 설정으로 현재 작동은 X
+ */
 ipcMain.on('mailto-external', (_event, mailtoUrl: string) => {
   if (mailtoUrl.startsWith('mailto:')) {
     shell.openExternal(mailtoUrl)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -55,3 +55,9 @@ app.on('window-all-closed', () => {
     app.quit()
   }
 })
+
+ipcMain.on('mailto-external', (_event, mailtoUrl: string) => {
+  if (mailtoUrl.startsWith('mailto:')) {
+    shell.openExternal(mailtoUrl)
+  }
+})

--- a/src/renderer/src/components/error-fallback.tsx
+++ b/src/renderer/src/components/error-fallback.tsx
@@ -1,0 +1,49 @@
+import { JSX, useCallback, useEffect, useRef } from 'react'
+import { toast } from 'sonner'
+
+export default function ErrorFallback({ error }: { error: Error }): JSX.Element {
+  const hasShownToast = useRef(false)
+
+  /**
+   * FIXME: 버전 하드코딩 되어 있음
+   */
+  const APP_VERSION = '0.0.1'
+
+  const handleSendMail = useCallback((): void => {
+    const subject = encodeURIComponent(`[Qgenie] ${APP_VERSION} - 오류 보고`)
+    /**
+     * TODO: 메일 양식 구체화
+     */
+    const body = encodeURIComponent(
+      [`오류 메시지:\n${error.message}`, `\n애플리케이션 정보:`, `\n사용자 환경:`].join('\n\n')
+    )
+
+    /**
+     * TODO: 오류 보고 메일 수정
+     */
+    const mailtoLink = `mailto:sample@sample.com?subject=${subject}&body=${body}`
+    window.electron?.ipcRenderer?.send?.('mailto-external', mailtoLink)
+  }, [error])
+
+  useEffect(() => {
+    if (!hasShownToast.current) {
+      toast.error('예기치 않은 오류가 발생했습니다.', {
+        description: '오류 공유 버튼을 눌러 개발자에게 알려주세요.',
+        action: {
+          label: '공유',
+          onClick: handleSendMail
+        }
+      })
+      hasShownToast.current = true
+    }
+  }, [handleSendMail])
+
+  /**
+   * TODO: 오류 페이지 스타일링
+   */
+  return (
+    <div className="flex flex-col gap-4 w-full h-screen overflow-hidden items-center justify-center">
+      <div className="text-red-600 font-bold text-2xl">오류</div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/error-fallback.tsx
+++ b/src/renderer/src/components/error-fallback.tsx
@@ -1,6 +1,14 @@
 import { JSX, useCallback, useEffect, useRef } from 'react'
 import { toast } from 'sonner'
 
+/**
+ * 에러 바운더리에 걸렸을 때 콜백되는 함수
+ *
+ * NOTE: 에러 메시지 공유는 sandbox 설정으로 동작 안함 (논의 필요)
+ *
+ * @param param0 error
+ * @returns error page
+ */
 export default function ErrorFallback({ error }: { error: Error }): JSX.Element {
   const hasShownToast = useRef(false)
 

--- a/src/renderer/src/components/ui/sonner.tsx
+++ b/src/renderer/src/components/ui/sonner.tsx
@@ -1,0 +1,24 @@
+import { useTheme } from 'next-themes'
+import { JSX } from 'react'
+import { Toaster as Sonner, ToasterProps } from 'sonner'
+
+const Toaster = ({ ...props }: ToasterProps): JSX.Element => {
+  const { theme = 'system' } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps['theme']}
+      className="toaster group"
+      style={
+        {
+          '--normal-bg': 'var(--popover)',
+          '--normal-text': 'var(--popover-foreground)',
+          '--normal-border': 'var(--border)'
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -2,9 +2,25 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
 import './assets/main.css'
+import { Toaster } from 'sonner'
+import { ErrorBoundary } from 'react-error-boundary'
+import ErrorFallback from '@/components/error-fallback'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <Toaster />
+    <ErrorBoundary
+      FallbackComponent={ErrorFallback}
+      onError={(error, info) => {
+        console.error('ErrorBoundary caught:', error)
+        window.electron?.ipcRenderer?.send?.('renderer-error', {
+          message: error.message,
+          stack: error.stack,
+          componentStack: info.componentStack
+        })
+      }}
+    >
+      <App />
+    </ErrorBoundary>
   </StrictMode>
 )


### PR DESCRIPTION
### JIRA Task 🔖
 
- **Ticket**: [FRT-27](https://qgenie.atlassian.net/browse/FRT-27)
- **Branch** : feature/FRT-27
 
### 작업 내용 📌
 
- `components.json` alias 수정 - shadcn 컴포넌트가 renderer 폴더에 들어가도록
- `main.tsx`에 Toaster, ErrorBoundary 컴포넌트 추가하여 전역 에러 관리
- `error-fallback.tsx`에서 에러 화면 표시 및 보고 기능 추가
 
<h3>테스트 방법 🧑🏻‍🔬</h3>
 
- `npm run dev`로 실행하여 확인
- 오류 페이지 확인은 `App.tsx` 에 다음 내용을 추가

```ts
  ...
  
  useEffect(() => {
    throw Error('테스트')
  }, [])
  
  return ( ...
```
 
### 참고 사항 📂
 
- `index.ts`에 sandbox 설정이 true로 되어 있는데 데이터베이스 드라이버 설치 등을 고려할 때 논의가 필요해 보임

[FRT-27]: https://qgenie.atlassian.net/browse/FRT-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ