### PR TITLE
[FRT-46] README.md 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,156 +1,137 @@
-# QGenie APP
+# QGenie App
 
-이 프로젝트는 QGenie 서비스의 ~를 제공합니다. ~목표로 합니다.
+QGenie 데스크톱 애플리케이션입니다.
 
 ---
 
 ## 🚀 시작하기
 
-### **Electron 앱 - 개발 환경 설정 가이드**
+### **1. 개발 환경 설정**
 
-이 가이드는 QGenie Electron 애플리케이션의 초기 설정 및 빌드 프로세스를 설명합니다.
+이 프로젝트는 `npm` 패키지 매니저와 `Node.js`가 필요합니다. `.nvmrc` 파일에 명시된 버전을 사용하는 것을 권장합니다.
 
-1. **개발 환경 설정**
+```bash
+# .nvmrc 파일에 맞는 Node.js 버전 사용
+nvm use
 
-   ```bash
-   #Electron 프로젝트 초기화
-   npm init -y
-   ```
+# 프로젝트 의존성 설치
+npm install
+```
 
-2. Electron 설치
+### **2. 개발 서버 실행**
 
-   ```bash
-    npm install --save-dev electron
-   ```
+다음 명령어를 실행하면 Electron 앱이 개발 모드로 실행됩니다. 소스 코드를 수정하면 자동으로 앱이 리로드됩니다.
 
-3. Electron 실행 환경을 위한 package.json 설정
-   package.json 파일을 수정하여 main 진입점과 Electron 앱 실행을 위한 start 스크립트를 포함합니다.
+```bash
+npm run dev
+```
 
-   필요에 따라 name, version, description을 조정하세요
+---
 
-   ```json
-   {
-     "name": "QGenie",
-     "version": "0.0.1",
-     "description": "QGenie Electron Application",
-     "main": "main.js", // 이 줄이 main.js 파일을 가리키는지 확인하세요.
-     "author": "QGenie Team",
-     "license": "ISC",
-     "scripts": {
-       "start": "electron ." // Electron 앱 실행을 위한 스크립트를 추가합니다.
-     },
-     "devDependencies": {
-       "electron": "^37.2.0" // 설치된 Electron 버전이 여기에 있는지 확인하세요.
-     }
-   }
-   ```
+## 📦 빌드 및 실행 파일 생성
 
-4. .dmg (macOS) 및 .exe (Windows) 파일 생성
-   이 섹션에서는 electron-builder를 설정하여 Electron 애플리케이션을 배포 가능한 파일로 패키징하는 방법을 다룹니다.
+이 프로젝트는 `electron-builder`를 사용하여 macOS, Windows, Linux용 실행 파일을 생성합니다. 모든 빌드 설정은 `electron-builder.yml` 파일에 정의되어 있습니다.
 
-   ```bash
-   #electron-builder를 개발 의존성으로 설치합니다.
-   npm install --save-dev electron
-   ```
+### **빌드 명령어**
 
-5. package.json에 빌드 스크립트 설정
-   package.json 파일을 수정하여 build 스크립트와 electron-builder를 위한 build 설정 섹션을 추가/업데이트합니다.
+각 운영체제에 맞는 빌드 명령어는 다음과 같습니다.
 
-   package.json 파일을 열고 scripts 및 build 섹션을 다음과 같이 추가/업데이트합니다:
+- **macOS (.dmg):**
 
-   ```json
-   {
-     "build": {
-       "appId": "com.qgenie.app", // 고유한 애플리케이션 ID
-       "productName": "QGenie", // 생성될 애플리케이션 파일의 이름 (예: QGenie.dmg, QGenie Setup.exe)
-       "files": [
-         "main.js",
-         "package.json",
-         "build/", // 아이콘 등을 위한 폴더
-         "dist/" // 렌더러/프론트엔드 빌드 결과물이 'dist' 폴더에 들어가는 경우
-         // 실제 프로젝트 구조에 따라 조정하세요.
-         // 예를 들어, 'renderer' 폴더가 있다면 "renderer/dist/**"가 필요할 수 있습니다.
-       ],
-       "mac": {
-         "category": "public.app-category.developer-tools",
-         "icon": "build/icon.icns", // macOS 아이콘 경로
-         "target": "dmg" // macOS용 타겟 형식
-       },
-       "win": {
-         "icon": "build/icon.ico", // Windows 아이콘 경로
-         "target": "nsis" // Windows용 설치 프로그램 타겟
-       }
-     }
-   }
-   ```
+  ```bash
+  npm run build -- --mac
+  ```
 
-   files 섹션에 대한 중요 참고 사항:
+- **Windows (.exe):**
 
-   files 배열은 electron-builder에게 프로젝트의 어떤 파일과 폴더를 최종 패키지된 애플리케이션에 포함해야 하는지 알려줍니다.
+  ```bash
+  npm run build -- --win
+  ```
 
-   프론트엔드 애플리케이션(예: React, Vue, Angular)이 특정 디렉토리(예: build, dist, out)로 빌드되는 경우, 해당 디렉토리를 files 배열에 반드시 포함해야 합니다 (예: "dist/" 또는 "path/to/your/frontend/build/folder/\*\*").
+- **Linux (.AppImage, .deb):**
+  ```bash
+  npm run build -- --linux
+  ```
 
-6. 애플리케이션 빌드
-   빌드 스크립트를 실행하여 운영 체제에 맞는 배포 파일을 생성합니다.
+빌드가 성공적으로 완료되면, 프로젝트 루트의 `dist/` 디렉토리에서 각 운영체제에 맞는 설치 파일을 찾을 수 있습니다.
 
-   ```bash
-   npm run build
-   ```
+---
 
-   성공적으로 실행되면, 프로젝트 루트의 dist/ 디렉토리에서 생성된 .dmg (macOS) 또는 .exe (Windows) 파일을 찾을 수 있습니다. macOS의 경우, dist/mac-arm64/ 또는 dist/mac/와 같은 플랫폼별 하위 폴더가 있을 수 있습니다.
+### 🏗️ 빌드 설정 (`electron-builder.yml`)
 
-7. Electron 앱 실행
-   ```bash
-   npm start
-   ```
+`electron-builder.yml` 파일은 애플리케이션 빌드에 필요한 모든 설정을 정의합니다. 주요 설정 항목은 다음과 같습니다.
 
-## 📦 배포 방법
+- **`appId`**: 애플리케이션의 고유 식별자입니다. (예: `com.Queryus.QGenie`)
+- **`productName`**: 설치 파일 및 애플리케이션 이름으로 사용됩니다.
+- **`directories`**:
+  - `output`: 빌드 결과물(설치 파일)이 생성될 디렉토리입니다. (기본값: `dist`)
+  - `buildResources`: 아이콘 등 빌드에 필요한 리소스 파일이 위치한 디렉토리입니다. (기본값: `build`)
+- **`files`**: 최종 패키지에 포함될 파일 및 디렉토리 목록입니다. `electron-vite`를 사용하므로, 컴파일된 결과물이 담긴 `out/**` 폴더를 포함합니다.
+- **`asarUnpack`**: `asar` 아카이브에 압축하지 않고 그대로 둘 파일 패턴을 지정합니다. `resources/**`에 포함된 외부 실행 파일들이 여기에 해당됩니다.
+- **`win`, `mac`, `linux`**: 각 운영체제별 세부 빌드 설정을 정의합니다. (아이콘, 타겟 포맷, 권한 등)
+- **`publish`**: GitHub Release 자동 업데이트를 위한 설정입니다. `provider: github`로 설정되어 있습니다.
 
-이 프로젝트는 GitHub Actions를 통해 실행 파일 빌드 및 배포가 자동화되어 있습니다. GitHub에서 새로운 태그를 발행하면 파이프라인이 자동으로 실행됩니다.
+---
 
-**태그 예시:** `v1.2.3`
+## ⚙️ CI/CD (자동화된 빌드 및 배포)
 
-- `1`: 큰 버전 (기존에 없던 새로운 도메인 추가)
-- `2`: 중간 버전 (기존 도메인에 새로운 기능 추가)
-- `3`: 패치 버전 (버그 수정, 코드 개선 등)
+이 프로젝트는 GitHub Actions를 통해 실행 파일 빌드 및 GitHub Release 배포가 자동화되어 있습니다.
 
-**배포 절차:**
+### **워크플로우 개요 (`.github/workflows/build_executables.yaml`)**
 
-1.  모든 기능 개발과 테스트가 완료된 코드를 `main` 브랜치에 병합(Merge)합니다.
-2.  레포지토리에서 **Releases** 탭으로 이동하여 **Create a new release** 버튼을 클릭합니다.
-3.  **Choose a tag** 항목을 클릭한 후 **Find or create a new tag** 부분에 버전(예: `v1.0.0`)과 같이 새로운 버전 태그를 입력하고 아래 **Create new tag**를 클릭하여 태그를 생성합니다.
-4.  ⭐**중요)** **Target** 드롭다운 메뉴에서 반드시 `main` 브랜치를 선택합니다.
+- **트리거:** GitHub에서 새로운 릴리즈(Release)가 `published` 상태가 될 때 워크플로우가 실행됩니다.
+- **주요 작업:**
+  1.  **빌드 (Build):** `macos-latest`와 `windows-latest` 환경에서 각각 앱을 빌드하여 `.dmg`와 `.exe` 파일을 생성합니다.
+  2.  **릴리즈 (Release):** 빌드된 실행 파일들을 해당 릴리즈의 에셋(Asset)으로 업로드합니다.
+  3.  **Homebrew 업데이트:** macOS용 `.dmg` 파일이 릴리즈되면, `Queryus/homebrew-qgenie` 저장소로 디스패치 이벤트를 보내 Homebrew Cask가 자동으로 업데이트되도록 합니다.
+  4.  **알림:** 파이프라인의 시작, 성공, 실패 여부를 디스코드 웹훅을 통해 알립니다.
+
+### **배포 절차**
+
+1.  모든 기능 개발과 테스트가 완료된 코드를 `master` 브랜치에 병합(Merge)합니다.
+2.  GitHub 레포지토리의 **Releases** 탭으로 이동하여 **"Draft a new release"** 버튼을 클릭합니다.
+3.  **"Select tag"** 드롭다운에서 새로운 버전 태그(예: `v1.0.0`)를 생성합니다.
+4.  ⭐**중요)** **Target** 드롭다운 메뉴에서 반드시 `master` 브랜치를 선택합니다.
 5.  제목에 버전을 입력하고 릴리즈 노트를 작성합니다.
 6.  🚨**주의)** **Publish release** 버튼을 클릭합니다.
     릴리즈 발행은 되돌릴 수 없습니다. 잘못된 릴리즈는 서비스에 직접적인 영향을 줄 수 있으니, 반드시 팀의 승인을 받고 신중하게 진행해 주십시오.
-7.  **Actions** 탭에 들어가 파이프라인을 확인 후 정상 배포되었다면 App 레포에 `develop` 브랜치에서 실행 파일을 확인합니다.
+7.  릴리즈가 발행되면 GitHub Actions 워크플로우가 자동으로 실행되어 빌드와 배포를 진행합니다.
+    완료된 경우 `Releases` 탭에서 실행 파일을 확인할 수 있습니다.
 8.  만약 실패하였다면 인프라 담당자에게 문의해주세요.
 
 ---
 
-
 ## 📦 패키지 매니저로 설치하기
 
 ### 💻 Homebrew로 설치하기 (macOS)
-#### macOS 사용자는 Homebrew를 사용하여 QGenie를 간편하게 설치하고 관리할 수 있습니다.
 
-##### 1. 사전 준비: Homebrew 설치
+macOS 사용자는 Homebrew를 사용하여 QGenie를 간편하게 설치하고 관리할 수 있습니다.
+
+0. **사전 준비: Homebrew 설치**
+
 ```bash
 # Homebrew가 설치되어 있지 않다면, 먼저 터미널을 열고 아래 명령어를 실행하여 Homebrew를 설치해주세요.
 /bin/bash -c "$(curl -fsSL [https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh](https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh))"
 ```
-##### 2. 설치 방법
+
+1.  **Homebrew Tap 등록 (최초 1회):**
+
 ```bash
 #Homebrew가 QGenie의 설치 정보를 찾을 수 있도록, 저희의 공식 리포지토리(Tap)를 등록해야 합니다. 이 과정은 PC 당 최초 한 번만 실행하면 됩니다.
 brew tap queryus/qgenie
+```
 
+2.  **QGenie 설치:**
+
+```bash
 # Tap을 추가했다면, 이제 brew install 명령어로 QGenie를 설치할 수 있습니다.
 brew install --cask qgenie
 
 # 설치가 완료되면 macOS의 응용 프로그램(Applications) 폴더에 QGenie.app이 추가됩니다.
 ```
 
-##### 3. 관리 방법
+3.  **업데이트 및 삭제:**
+
 ```bash
 # QGenie의 새로운 버전이 출시되면, 아래 명령어로 간단하게 최신 버전으로 업데이트할 수 있습니다.
 brew upgrade --cask qgenie


### PR DESCRIPTION
<h3> JIRA Task 🔖</h3>

- **Tickets**: [FRT-46](https://qgenie.atlassian.net/browse/FRT-46)
- **Branch**: feature/FRT-46

<h3>작업 내용 📌</h3>
 
- README.md에 빌드 관련 변경사항 반영
- CI/CD 관련 간단 설명 추가
- 배포 절차 설명 속 브랜치 이름 최신화
- 배포 절차의 기존 설명 중 7번이 모호하여 수정
```bash
# 기존 설명
Actions 탭에 들어가 파이프라인을 확인 후 정상 배포되었다면 App 레포에 develop 브랜치에서 실행 파일을 확인합니다.

# 변경된 설명
릴리즈가 발행되면 GitHub Actions 워크플로우가 자동으로 실행되어 빌드와 배포를 진행합니다. 
완료된 경우 `Releases` 탭에서 실행 파일을 확인할 수 있습니다.
```

[FRT-46]: https://qgenie.atlassian.net/browse/FRT-46?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ